### PR TITLE
chore(project): move dependencies to devDependencies

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,7 @@
 examples
 zip
 test
+scripts
+
+# Ignore font source folders
+**/sources/**

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "devDependencies": {
     "archiver": "^3.0.0",
     "fs-extra": "^7.0.0",
-    "git-branch": "^2.0.1"
+    "git-branch": "^2.0.1",
     "husky": "^0.14.3",
     "lint-staged": "^4.3.0",
     "node-sass": "^4.7.2",

--- a/package.json
+++ b/package.json
@@ -19,12 +19,10 @@
     "prettier": "prettier --write \"**/*.{scss}\"",
     "prepare": "yarn build"
   },
-  "dependencies": {
-    "archiver": "^3.0.0",
-    "git-branch": "^2.0.1"
-  },
   "devDependencies": {
+    "archiver": "^3.0.0",
     "fs-extra": "^7.0.0",
+    "git-branch": "^2.0.1"
     "husky": "^0.14.3",
     "lint-staged": "^4.3.0",
     "node-sass": "^4.7.2",


### PR DESCRIPTION
Addresses part of #177 

Move `archiver` and `git-branch` to `devDependencies`.