### PR TITLE
fix(Plex Mono): specify italic style when italic font is declared

### DIFF
--- a/_mono.scss
+++ b/_mono.scss
@@ -17,7 +17,7 @@ $plex-font-path: '~@ibm/plex/IBM-Plex-Mono' !default;
 @mixin thin-italic {
   @font-face {
     font-family: 'IBM Plex Mono';
-    font-style: normal;
+    font-style: italic;
     font-weight: 100;
     font-display: $plex-font-display;
     src: url('#{$plex-font-path}/fonts/complete/woff2/IBMPlexMono-ThinItalic.woff2')
@@ -48,7 +48,7 @@ $plex-font-path: '~@ibm/plex/IBM-Plex-Mono' !default;
 @mixin extralight-italic {
   @font-face {
     font-family: 'IBM Plex Mono';
-    font-style: normal;
+    font-style: italic;
     font-weight: 200;
     font-display: $plex-font-display;
     src: url('#{$plex-font-path}/fonts/complete/woff2/IBMPlexMono-ExtraLightItalic.woff2')
@@ -79,7 +79,7 @@ $plex-font-path: '~@ibm/plex/IBM-Plex-Mono' !default;
 @mixin light-italic {
   @font-face {
     font-family: 'IBM Plex Mono';
-    font-style: normal;
+    font-style: italic;
     font-weight: 300;
     font-display: $plex-font-display;
     src: url('#{$plex-font-path}/fonts/complete/woff2/IBMPlexMono-LightItalic.woff2')
@@ -110,7 +110,7 @@ $plex-font-path: '~@ibm/plex/IBM-Plex-Mono' !default;
 @mixin regular-italic {
   @font-face {
     font-family: 'IBM Plex Mono';
-    font-style: normal;
+    font-style: italic;
     font-weight: 400;
     font-display: $plex-font-display;
     src: url('#{$plex-font-path}/fonts/complete/woff2/IBMPlexMono-Italic.woff2')
@@ -141,7 +141,7 @@ $plex-font-path: '~@ibm/plex/IBM-Plex-Mono' !default;
 @mixin text-italic {
   @font-face {
     font-family: 'IBM Plex Mono';
-    font-style: normal;
+    font-style: italic;
     font-weight: 450;
     font-display: $plex-font-display;
     src: url('#{$plex-font-path}/fonts/complete/woff2/IBMPlexMono-TextItalic.woff2')
@@ -172,7 +172,7 @@ $plex-font-path: '~@ibm/plex/IBM-Plex-Mono' !default;
 @mixin medium-italic {
   @font-face {
     font-family: 'IBM Plex Mono';
-    font-style: normal;
+    font-style: italic;
     font-weight: 500;
     font-display: $plex-font-display;
     src: url('#{$plex-font-path}/fonts/complete/woff2/IBMPlexMono-MediumItalic.woff2')
@@ -203,7 +203,7 @@ $plex-font-path: '~@ibm/plex/IBM-Plex-Mono' !default;
 @mixin semibold-italic {
   @font-face {
     font-family: 'IBM Plex Mono';
-    font-style: normal;
+    font-style: italic;
     font-weight: 600;
     font-display: $plex-font-display;
     src: url('#{$plex-font-path}/fonts/complete/woff2/IBMPlexMono-SemiBoldItalic.woff2')
@@ -234,7 +234,7 @@ $plex-font-path: '~@ibm/plex/IBM-Plex-Mono' !default;
 @mixin bold-italic {
   @font-face {
     font-family: 'IBM Plex Mono';
-    font-style: normal;
+    font-style: italic;
     font-weight: 700;
     font-display: $plex-font-display;
     src: url('#{$plex-font-path}/fonts/complete/woff2/IBMPlexMono-BoldItalic.woff2')


### PR DESCRIPTION
Italic styles were being rendered by default for `mono` fonts