### PR TITLE
chore: onboard @ibm/plex to IBM Telemetry 🚀

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,3 +68,11 @@ To build binary font files from .vfb sources you need [FontLab Studio 5](https:/
 From FontLab, run `IBM Plex export FDK files.py` and choose a directory with IBM Plex .vfb source files. The script will create a new directory called `fdk` in which subdirectories are created for every font. The script will export files necessary for AFDKO in those subdirectories.
 
 Subsequently, OpenType Fonts (OTFs) or TrueType Fonts (TTFs) can be generated from the command line using `makeotf`, which is part of the AFDKO toolset. Information and usage instructions can be found by executing `makeotf -h`.
+
+## <picture><source height="20" width="20" media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-dark.svg"><source height="20" width="20" media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-light.svg"><img height="20" width="20" alt="IBM Telemetry" src="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-light.svg"></picture> IBM Telemetry
+
+This package uses IBM Telemetry to collect metrics data. By installing this package as a dependency
+you are agreeing to telemetry collection. To opt out, see
+[opting out of IBM Telemetry data collection](https://github.com/ibm-telemetry/telemetry-js/tree/main#opting-out-of-ibm-telemetry-data-collection).
+For more information on the data being collected, please see the
+[IBM Telemetry documentation](https://github.com/ibm-telemetry/telemetry-js/tree/main#ibm-telemetry-collection-basics).

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "!IBM-Plex-Sans-KR/fonts/hinted/**/woff2",
     "!IBM-Plex-Sans-KR/fonts/hinted/**/woff",
     "!IBM-Plex-Sans-JP/fonts/hinted/**/woff2",
-    "!IBM-Plex-Sans-JP/fonts/hinted/**/woff"
+    "!IBM-Plex-Sans-JP/fonts/hinted/**/woff",
+    "telemetry.yml"
   ],
   "scripts": {
     "clean": "rimraf css scss deploy-preview",
@@ -30,6 +31,7 @@
     "build:scss": "node ./scripts/generate-scss.js",
     "build:deploy-preview": "gulp build:deploy-preview",
     "test": "parcel serve ./deploy-preview/index.html",
+    "postinstall": "ibmtelemetry --config=telemetry.yml",
     "precommit": "lint-staged",
     "prettier": "prettier --write \"**/*.{scss}\"",
     "prepare": "husky install && yarn build",
@@ -86,5 +88,8 @@
     "name": "ibm-plex",
     "sassDir": "scss",
     "needs": "*"
+  },
+  "dependencies": {
+    "@ibm/telemetry-js": "^1.3.0"
   }
 }

--- a/telemetry.yml
+++ b/telemetry.yml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://unpkg.com/@ibm/telemetry-config-schema@v1/dist/config.schema.json
+
+version: 1
+projectId: bec7aecb-9d5a-4b18-8528-7762bd6232a3
+endpoint: https://collector-prod.1am6wm210aow.us-south.codeengine.appdomain.cloud/v1/metrics
+collect:
+  npm:
+    dependencies: null

--- a/yarn.lock
+++ b/yarn.lock
@@ -246,6 +246,11 @@
   resolved "https://registry.yarnpkg.com/@iarna/toml/-/toml-2.2.5.tgz#b32366c89b43c6f8cefbdefac778b9c828e3ba8c"
   integrity sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==
 
+"@ibm/telemetry-js@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@ibm/telemetry-js/-/telemetry-js-1.3.0.tgz#321f2ed4bbbc78d69dc1ee9cb6f83d2d2af9baef"
+  integrity sha512-9gIkyF2B9RizWN6rsdQN76DN6D+/Xbr4HGTwm6EUujfXvEVtWbf4jzxDFwKvZkeTC2tjHpkUNJQKdivbMKt8yg==
+
 "@jridgewell/gen-mapping@^0.3.0":
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz#7e02e6eb5df901aaedb08514203b096614024098"


### PR DESCRIPTION
Adds the config file and dependency necessary to start tracking telemetry data via [IBM Telemetry](https://github.com/ibm-telemetry/telemetry-js) for the packages:

- `@ibm/plex`

#### What did you change?

**New**

- Adds @ibm/telemetry-js dependency
- Adds telemetry.yml config file
- Adds readme telemetry notice
- Adds postinstall script to use the telemetry command
- Adds telemetry.yml as an exported file if the package.json

**Changed**

- N/A

**Removed**

- N/A

#### How did you test and verify your work?

Please look through package.json config files and ensure all necessary modifications have been made so that the "telemetry.yml" config file is included in the release version of each package.

**PLEASE NOTE:** In order for IBM Telemetry to start collecting data for this project, a new build must be published including these changes.