### PR TITLE
deps: update @ibm/telemetry-js version to 1.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,6 +90,6 @@
     "needs": "*"
   },
   "dependencies": {
-    "@ibm/telemetry-js": "^1.3.0"
+    "@ibm/telemetry-js": "^1.5.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -246,10 +246,10 @@
   resolved "https://registry.yarnpkg.com/@iarna/toml/-/toml-2.2.5.tgz#b32366c89b43c6f8cefbdefac778b9c828e3ba8c"
   integrity sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==
 
-"@ibm/telemetry-js@^1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@ibm/telemetry-js/-/telemetry-js-1.3.0.tgz#321f2ed4bbbc78d69dc1ee9cb6f83d2d2af9baef"
-  integrity sha512-9gIkyF2B9RizWN6rsdQN76DN6D+/Xbr4HGTwm6EUujfXvEVtWbf4jzxDFwKvZkeTC2tjHpkUNJQKdivbMKt8yg==
+"@ibm/telemetry-js@^1.5.1":
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/@ibm/telemetry-js/-/telemetry-js-1.5.1.tgz#a4bcb51a8223f2c7b20fe5092768de8e3dcf38b9"
+  integrity sha512-Hu8iJAy9UGvjWjpMmHTNgekr2+b44nvp37RxSdWogpkSO7bPajR3CbDvb0QWAvJ7KnW+VmB3aDi1rlNsIyrZVw==
 
 "@jridgewell/gen-mapping@^0.3.0":
   version "0.3.3"


### PR DESCRIPTION
Updates `@ibm/telemetry-js` version to v1.5.1