### PR TITLE
build(npm): push to npm only used fonts to reduce size

### DIFF
--- a/packages/plex-math/package.json
+++ b/packages/plex-math/package.json
@@ -10,7 +10,8 @@
   "files": [
     "css",
     "scss",
-    "fonts"
+    "fonts/complete/woff/*",
+    "fonts/complete/woff2/*"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/plex-mono/package.json
+++ b/packages/plex-mono/package.json
@@ -10,7 +10,9 @@
   "files": [
     "css",
     "scss",
-    "fonts"
+    "fonts/complete/woff/*",
+    "fonts/complete/woff2/*",
+    "fonts/split/woff2/*"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/plex-sans-arabic/package.json
+++ b/packages/plex-sans-arabic/package.json
@@ -10,7 +10,8 @@
   "files": [
     "css",
     "scss",
-    "fonts"
+    "fonts/complete/woff/*",
+    "fonts/complete/woff2/*"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/plex-sans-condensed/package.json
+++ b/packages/plex-sans-condensed/package.json
@@ -10,7 +10,9 @@
   "files": [
     "css",
     "scss",
-    "fonts"
+    "fonts/complete/woff/*",
+    "fonts/complete/woff2/*",
+    "fonts/split/woff2/*"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/plex-sans-devanagari/package.json
+++ b/packages/plex-sans-devanagari/package.json
@@ -10,7 +10,8 @@
   "files": [
     "css",
     "scss",
-    "fonts"
+    "fonts/complete/woff/*",
+    "fonts/complete/woff2/*"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/plex-sans-hebrew/package.json
+++ b/packages/plex-sans-hebrew/package.json
@@ -10,7 +10,8 @@
   "files": [
     "css",
     "scss",
-    "fonts"
+    "fonts/complete/woff/*",
+    "fonts/complete/woff2/*"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/plex-sans-jp/package.json
+++ b/packages/plex-sans-jp/package.json
@@ -10,7 +10,9 @@
   "files": [
     "css",
     "scss",
-    "fonts"
+    "fonts/complete/woff/hinted/*",
+    "fonts/complete/woff2/hinted/*",
+    "fonts/split/woff2/hinted/*"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/plex-sans-kr/package.json
+++ b/packages/plex-sans-kr/package.json
@@ -10,7 +10,9 @@
   "files": [
     "css",
     "scss",
-    "fonts"
+    "fonts/complete/woff/hinted/*",
+    "fonts/complete/woff2/hinted/*",
+    "fonts/split/woff2/hinted/*"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/plex-sans-tc/package.json
+++ b/packages/plex-sans-tc/package.json
@@ -10,7 +10,9 @@
   "files": [
     "css",
     "scss",
-    "fonts"
+    "fonts/complete/woff/hinted/*",
+    "fonts/complete/woff2/hinted/*",
+    "fonts/split/woff2/hinted/*"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/plex-sans-thai-looped/package.json
+++ b/packages/plex-sans-thai-looped/package.json
@@ -10,7 +10,8 @@
   "files": [
     "css",
     "scss",
-    "fonts"
+    "fonts/complete/woff/*",
+    "fonts/complete/woff2/*"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/plex-sans-thai/package.json
+++ b/packages/plex-sans-thai/package.json
@@ -10,7 +10,8 @@
   "files": [
     "css",
     "scss",
-    "fonts"
+    "fonts/complete/woff/*",
+    "fonts/complete/woff2/*"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/plex-sans/package.json
+++ b/packages/plex-sans/package.json
@@ -10,7 +10,9 @@
   "files": [
     "css",
     "scss",
-    "fonts"
+    "fonts/complete/woff/*",
+    "fonts/complete/woff2/*",
+    "fonts/split/woff2/*"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/plex-serif/package.json
+++ b/packages/plex-serif/package.json
@@ -10,7 +10,9 @@
   "files": [
     "css",
     "scss",
-    "fonts"
+    "fonts/complete/woff/*",
+    "fonts/complete/woff2/*",
+    "fonts/split/woff2/*"
   ],
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Limit font types published to npm to reduce bundle size