### PR TITLE
docs(plex-sans-tc): correct css font-family

### DIFF
--- a/packages/plex-sans-tc/README.md
+++ b/packages/plex-sans-tc/README.md
@@ -76,7 +76,7 @@ IBM Plex Sans Chinese TC typeface weights map:
 Below are the `font-family` rules for the family:
 
 ```css
-font-family: 'IBM Plex Sans KR';
+font-family: 'IBM Plex Sans TC';
 ```
 
 ## Building the fonts from source


### PR DESCRIPTION
small typo in the plex-sans-tc readme doc 