### PR TITLE
fix(preview): resolve Windows path generation and handle undefined font configurations cleanly

### DIFF
--- a/gulp-tasks/build/deploy-preview.js
+++ b/gulp-tasks/build/deploy-preview.js
@@ -21,19 +21,24 @@ const _LIST_PACKAGES = [];
  * List packages with output CSS
  */
 function _listPackages() {
-
   const listPackages = globSync(`packages/**/${config.cssSrc}`);
 
-  listPackages.length && listPackages.forEach(( path ) => {
+  if (listPackages.length) {
+    listPackages.forEach((pathStr) => {
+      // FIX: Handles both Windows backward slashes (\) and Unix forward slashes (/)
+      const pathParts = pathStr.split(/[\\/]/);
+      const family = pathParts[1];
 
-    const [, family] = path.split("/");
-
-    _LIST_PACKAGES.push({
-      family, 
-      path,
-      cssPath: `assets/${family}/${config.cssSrc}/ibm-${family}-all.css`
+      // CRITICAL GUARD: Only register valid, existing font package directories
+      if (family && family !== 'undefined') {
+        _LIST_PACKAGES.push({
+          family, 
+          path: pathStr,
+          cssPath: `assets/${family}/${config.cssSrc}/ibm-${family}-all.css`
+        });
+      }
     });
-  });
+  }
 }
 
 /**
@@ -43,14 +48,16 @@ const _transformFamilyMap = {
   jp: "JP",
   kr: "KR",
   tc: "TC"
-}
+};
 
 function _transformFamilyName(family) {
+  // CRITICAL GUARD: Stop string operation crashes if family data string is corrupt
+  if (!family || typeof family !== 'string' || family === 'undefined') {
+    return "IBM Plex";
+  }
 
   return "IBM " + family.split("-").map((part) => {
-
     return _transformFamilyMap[part] ? _transformFamilyMap[part] : part.charAt(0).toUpperCase() + part.slice(1);
-
   }).join(" ");
 }
 
@@ -60,7 +67,6 @@ function _transformFamilyName(family) {
  * @returns {*} gulp stream
  */
 function _copyTest() {
-
   _listPackages();
 
   return gulp
@@ -74,7 +80,6 @@ function _copyTest() {
  * @returns {*} gulp stream
  */
 function _injectHtml() {
-
   console.log("Inject html");
 
   const injectCss = [];
@@ -84,41 +89,42 @@ function _injectHtml() {
   ];
   
   _LIST_PACKAGES.forEach(({ family, cssPath }) => {
+    // Double check to prevent injecting undefined layouts into stream
+    if (!family || family === 'undefined') return;
 
     injectCss.push(`${config.deployPreviewPath}/${cssPath}`);
-
     injectStyle.push(`div[data-family="${family}"] { display: initial; }`);
 
     const transformedFamily = _transformFamilyName(family);
-
-    injectOptions.push(`<option value="${transformedFamily}">${transformedFamily}</option>`)
+    injectOptions.push(`<option value="${transformedFamily}">${transformedFamily}</option>`);
   });
+
+  // CRITICAL FIX FOR GULP GLOB ERRORS:
+  // If no packages compiled yet, clean array out to prevent singular glob crash
+  const verifiedCssSources = injectCss.filter(Boolean);
 
   const target = gulp.src(`${config.deployPreviewPath}/index.html`);
 
   return target
     .pipe(inject(
-      gulp.src(injectCss, { read: false }), {
+      gulp.src(verifiedCssSources, { read: false, allowEmpty: true }), {
         transform: function(filepath) {
-          
           return `<link rel="stylesheet" href="${filepath.replace("/public/", "")}" />`;
         }
       }
     ))
     .pipe(inject(
-      gulp.src(config.testSrc + "/inject.txt", { ready: false }), {
+      gulp.src(config.testSrc + "/inject.txt", { read: false, allowEmpty: true }), {
         starttag: '<!-- inject:style -->',
         transform: function() {
-
           return `<style>\n${injectStyle.join('\n')}\n</style>`;
         }
       }
     ))
     .pipe(inject(
-      gulp.src(config.testSrc + "/inject.txt", { ready: false }), {
+      gulp.src(config.testSrc + "/inject.txt", { read: false, allowEmpty: true }), {
         starttag: '<!-- inject:options -->',
         transform: function() {
-
           return injectOptions.join('\n');
         }
       }
@@ -132,11 +138,14 @@ function _injectHtml() {
  * @returns {*} gulp stream
  */
 function _copyCss(done) {
-
   console.log("Copy css");
 
-  const tasks = _LIST_PACKAGES.map(({ path, family }) => {
+  // Safety exit if package tree array parsing state came back blank
+  if (_LIST_PACKAGES.length === 0) {
+    return done();
+  }
 
+  const tasks = _LIST_PACKAGES.map(({ path, family }) => {
     return () => gulp
       .src([path + "/*.*", "!" + path + "/*.min.*"])
       .pipe(replace(/local\(.*?\),/gm, ""))
@@ -155,11 +164,13 @@ function _copyCss(done) {
  * @returns {*} gulp stream
  */
 function _copyFonts(done) {
-
   console.log("Copy fonts");
 
-  const tasks = _LIST_PACKAGES.map(({ path, family }) => {
+  if (_LIST_PACKAGES.length === 0) {
+    return done();
+  }
 
+  const tasks = _LIST_PACKAGES.map(({ path, family }) => {
     return () => gulp
       .src([`packages/${family}/fonts/**/*.*`])
       .pipe(gulp.dest([`${config.deployPreviewAssets}/${family}/fonts`]));
@@ -177,7 +188,6 @@ function _copyFonts(done) {
  * @returns {*} gulp stream
  */
 function _copyPreview() {
-
   return gulp
     .src(["scripts/preview.js"])
     .pipe(gulp.dest(config.deployPreviewPath));

--- a/package.json
+++ b/package.json
@@ -14,23 +14,24 @@
   "workspaces": [
     "packages/*"
   ],
-  "scripts": {
+    "scripts": {
     "clean": "rimraf public zip dist",
     "clean:family": "node ./scripts/clean.js",
     "build": "yarn clean:family && yarn build:scss && yarn build:css",
     "build:zip": "rimraf zip && yarn build && node ./scripts/prepare-zip.js && sh scripts/zip.sh && node ./scripts/clean-zip.js",
     "build:css": "node ./scripts/compile-css.js",
     "build:scss": "node ./scripts/generate-scss.js",
-    "build:deploy-preview": "gulp build:deploy-preview",
+    "build:deploy-preview": "yarn build:scss && yarn build:css && gulp build:deploy-preview",
     "build:cdn": "rimraf cdn && yarn build && node ./scripts/generate-cdn.js && webpack --config webpack.config.js",
     "unicodes": "node ./scripts/parse-unicodes.js",
-    "preview": "rimraf public dist && yarn build:deploy-preview && node ./public/preview.js",
+    "preview": "rimraf public dist && yarn build && yarn build:deploy-preview && node ./public/preview.js",
     "precommit": "lint-staged",
     "prettier": "prettier --write \"**/*.{scss}\"",
     "prepare": "husky install",
     "test:e2e:local": "start-server-and-test 'http-server -c-1 public --silent' 8080 'percy exec --config cypress/.percy.json -- cypress run --config-file cypress/cypress.json'",
     "test:e2e:local:no-percy": "start-server-and-test 'http-server -c-1 public --silent' 8080 'cypress run --config-file cypress/cypress.json'"
   },
+
   "devDependencies": {
     "@commitlint/cli": "^17.0.1",
     "@commitlint/config-conventional": "^17.0.0",


### PR DESCRIPTION
### Description
This PR resolves the deployment preview console crashes reported in #631.

### Changes Introduced
1. **Chained Compilation Scripts:** Configured `package.json` to ensure style sheets build via `yarn build` before starting layout previews.
2. **Cross-Platform Path Support:** Updated file path parsing inside `deploy-preview.js` with a robust separator regex (`/[\\/]/`) to handle Windows backward slashes natively.
3. **Defensive Validation Guards:** Added conditional logic parameters to filter out unmapped directory values cleanly instead of throwing exception crashes.

*Tested successfully on Windows 11 with Node v22 and Yarn.*

